### PR TITLE
Add validation step before file creation

### DIFF
--- a/public/css/w2helper.css
+++ b/public/css/w2helper.css
@@ -430,7 +430,8 @@ textarea {
   text-indent: 15px;
 }
 
-.help-validations .invalid {
+.help-validations .invalid,
+.modal-content .invalid {
   font-weight: bold;
   background-color: transparent;
   color: red;

--- a/public/js/lib/w2DataValidator.js
+++ b/public/js/lib/w2DataValidator.js
@@ -1,0 +1,81 @@
+var validationTypes = {
+  report: {
+    forms: ['report'],
+    children: 'businesses'
+  },
+  business: {
+    forms: ['business'],
+    children: 'employees'
+  },
+  employee: {
+    forms: ['w2']
+  }
+}
+
+function W2DataValidator(data) {
+  var data = data;
+  var state = {
+    passed: true,
+    errors: []
+  };
+
+  var validate = function() {
+    validateDataForTypeAtIndex(data, 'report', 0);
+    data.businesses.forEach(function(business, bindex) {
+      validateDataForTypeAtIndex(business, 'business', bindex);
+      business.employees.forEach(function(employee, eindex) {
+        validateDataForTypeAtIndex(employee, 'employee', eindex);
+      });
+    });
+  }
+
+  var validateDataForTypeAtIndex = function(data, type, index) {
+    validationTypes[type].forms.forEach(function(form) {
+      if(data.forms && data.forms[form]) {
+        for(field in data.forms[form]) {
+          if(!data.forms[form][field].valid.passed) {
+            state.passed = false;
+            state.errors.push({
+              type: type,
+              index: index,
+              object: form + ' form',
+              error: 'invalid'
+            });
+            break;
+          }
+        }
+      } else {
+        state.passed = false;
+        state.errors.push({
+          type: type,
+          index: index,
+          object: form,
+          error: 'missing'
+        });
+      }
+    });
+    if(validationTypes[type].children) {
+      if(!data[validationTypes[type].children] ||
+         !data[validationTypes[type].children].length) {
+        state.errors.push({
+          type: type,
+          index: index,
+          object: validationTypes[type].children,
+          error: 'missing'
+        })
+      }
+    }
+  }
+
+  var getState = function() {
+    return state;
+  }
+
+  validate();
+
+  return {
+    getState: getState
+  }
+}
+
+module.exports = W2DataValidator;

--- a/public/js/templates/fileModal.js
+++ b/public/js/templates/fileModal.js
@@ -2,17 +2,25 @@ var fileModalTemplate = $.templates('fileModal',
 
 "<div class='modal-background' id='{{:domID}}' {{if !visible}}hidden{{/if}}>" +
 "  <div class='modal-content'>" +
-"    <h3>You're almost there!</h3>" +
+"    {{if state == 'failed'}}" +
+"      <h3>Whoops!</h3>" +
+"    {{else}}" +
+"      <h3>You're almost there!</h3>" +
+"    {{/if}}" +
 "    <div class='body'>" +
 "      {{if state == 'failed'}}" +
 "        <p>" +
-"          Uh oh." +
+"          Looks like your report failed validation:" +
 "        </p>" +
 "        <p>" +
-"          Looks like your report failed validation for some reason..." +
+"          {{for errors}}" +
+"            <span class='invalid'>" +
+"              {{:type.charAt(0).toUpperCase().concat(type.substring(1))}} {{:index + 1}}: {{:error.charAt(0).toUpperCase().concat(error.substring(1))}} {{:object}}" +
+"            </span><br>" +
+"          {{/for}}" +
 "        </p>" +
 "        <p>" +
-"          Give your forms a once-over, fill any red fields you find, and try again!" +
+"          Give these items a once-over, fill any red fields you find, and try again!" +
 "        </p>" +
 "      {{else}}" +
 "        <p>" +

--- a/todo.txt
+++ b/todo.txt
@@ -1,17 +1,15 @@
 TODO:
 - MVP:
-  - Good behavior
-  - Good styling
+  - Save/load report (in localStorage)
 - Improvements:
   - Features:
-    - Save/load report (in localStorage)
+    - Save/load multiple reports (in localStorage)
     - Multiple businesses
     - More forms
     - State-specific options
     - Import from file
   - Frontend:
     - Readme
-    - Disclaimer
     - License?
   - Code Health:
     - Restructure project


### PR DESCRIPTION
The file creation step will now be preceded by a validation step. The file will no actually be generated unless the given data is actually valid.

This checks whether all the required objects are present (report has at least one business with at least one employee), and all validations for the forms/fields for each object are passing.

Doesn't add much processing time, as the validation states are already passed in the with serialized data, so we're just taking a peek at them.

It also displays the reasons for failure in the file modal's "failed" screen.

This is live at https://w2helper.firebaseapp.com/

@deetz63 Check it out, along with the UI changes from #12